### PR TITLE
Port forward UDP

### DIFF
--- a/vbmc/vbmc.go
+++ b/vbmc/vbmc.go
@@ -74,7 +74,7 @@ func Create(domainName string, address string, port int, username string, passwo
 		"-e",
 		fmt.Sprintf("VBMC_EMULATOR_PASSWORD=%s", password),
 		"-p",
-		fmt.Sprintf("%s:%d:6230", address, port),
+		fmt.Sprintf("%s:%d:6230/udp", address, port),
 		"ruilopes/vbmc-emulator")
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func Delete(domainName string) error {
 }
 
 func Get(domainName string) (*Vbmc, error) {
-	stdout, err := docker("port", getContainerName(domainName), "6230")
+	stdout, err := docker("port", getContainerName(domainName), "6230/udp")
 	if err != nil {
 		if execError, ok := err.(*VbmcExecError); ok {
 			if strings.Contains(execError.Stderr, "No such container") {


### PR DESCRIPTION
Hey, I was having problems with the ipmitool connecting to the vbmcd instances in the docker containers. The tool would just timeout when reading the chassis power status.

After some investigation it turns out that docker was forwarding on TCP and not UDP, see below for an example terraform setup.

I can only suspect that either docker was forwarding both TCP/UDP in the past, or that vbmcd was listening on TCP. Perhaps another amicable change is to explicitly configure vbmcd to listen on TCP. 

## Example setup

```terraform
terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
      version = "0.6.14"
    }
    vbmc = {
      source = "rgl/vbmc"
      version = "0.3.0"
    }
  }
}

resource "vbmc_vbmc" "nodes" {
  domain_name = element(libvirt_domain.nodes.*.name, count.index)
  port = 6233 + count.index
  count = 3
}

resource "libvirt_domain" "nodes" {
  name   = "node-${count.index}"
  autostart = false
  running = false

  video {
    type = "none"
  }

  count = 3
}
```

After applying the terraform above, docker is forwarding TCP ports to 6230 for each container:
```
$ docker ps
CONTAINER ID   IMAGE                    COMMAND             CREATED         STATUS         PORTS                      NAMES                 
299e8de9e545   ruilopes/vbmc-emulator   "./entrypoint.sh"   7 seconds ago   Up 5 seconds   127.0.0.1:6234->6230/tcp   vbmc-emulator-node-1  
a96ab698e37f   ruilopes/vbmc-emulator   "./entrypoint.sh"   7 seconds ago   Up 5 seconds   127.0.0.1:6235->6230/tcp   vbmc-emulator-node-2  
dbad932aaa99   ruilopes/vbmc-emulator   "./entrypoint.sh"   7 seconds ago   Up 5 seconds   127.0.0.1:6233->6230/tcp   vbmc-emulator-node-0  
```

However inside the containers, vbmcd is listening on UDP on 6230:
```
$ docker exec -it vbmc-emulator-node-0 sh -c 'apt-get update && apt-get install -y iproute2 && ss -anutlp'
...
Netid           State            Recv-Q           Send-Q                      Local Address:Port                        Peer Address:Port           Process                       
udp             UNCONN           0                0                                 0.0.0.0:6230                             0.0.0.0:*               users:(("vbmcd",pid=10,fd=6))
tcp             LISTEN           0                100                             127.0.0.1:50891                            0.0.0.0:*               users:(("vbmcd",pid=1,fd=12))
```

So, adding the `/udp` specification in this PR results in the following after a `terraform apply`:
```
$ docker ps                                                                                                      
CONTAINER ID   IMAGE                    COMMAND             CREATED          STATUS          PORTS                      NAMES                  
f091be72bc5e   ruilopes/vbmc-emulator   "./entrypoint.sh"   35 seconds ago   Up 34 seconds   127.0.0.1:6234->6230/udp   vbmc-emulator-node-1   
5b68afb64cab   ruilopes/vbmc-emulator   "./entrypoint.sh"   35 seconds ago   Up 34 seconds   127.0.0.1:6235->6230/udp   vbmc-emulator-node-2   
932e817cfce6   ruilopes/vbmc-emulator   "./entrypoint.sh"   35 seconds ago   Up 34 seconds   127.0.0.1:6233->6230/udp   vbmc-emulator-node-0   
```